### PR TITLE
Update vocab.cljc

### DIFF
--- a/src/fluree/db/connection/vocab.cljc
+++ b/src/fluree/db/connection/vocab.cljc
@@ -86,7 +86,7 @@
   (system-iri "parallelism"))
 
 (def cache-max-mb
-  (system-iri "cachMaxMb"))
+  (system-iri "cacheMaxMb"))
 
 (def commit-storage
   (system-iri "commitStorage"))


### PR DESCRIPTION
Fix type of `cachMaxMb` -> `cacheMaxMb`